### PR TITLE
Implement beach tennis bet game

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -11,9 +11,7 @@
       <app-start-session *ngIf="(gameSessionService.currentStepId$ | async) === 'start'"/>
       <app-countdown *ngIf="(gameSessionService.currentStepId$ | async) === 'countdown'"/>
       <app-game-transition *ngIf="(gameSessionService.currentStepId$ | async) === 'game-transition'"/>
-      <app-memory-card-game *ngIf="(gameSessionService.currentStepId$ | async) === 'memory'"/>
-      <app-spot-the-difference *ngIf="(gameSessionService.currentStepId$ | async) === 'spot-the-difference'"/>
-      <app-reaction-time *ngIf="(gameSessionService.currentStepId$ | async) === 'reaction-time'"/>
+      <app-beach-tennis-bet *ngIf="(gameSessionService.currentStepId$ | async) === 'beach-tennis-bet'"/>
       <app-loading-results *ngIf="(gameSessionService.currentStepId$ | async) === 'loading-results'"/>
       <app-final-results *ngIf="(gameSessionService.currentStepId$ | async) === 'final-results'"/>
     </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,13 +3,11 @@ import { CommonModule } from '@angular/common';
 import { GameStateInfoComponent } from './common/game-state-info/game-state-info.component';
 import { GameSessionService } from './services/game-session.service';
 import { StartSessionComponent } from './views/start-session/start-session.component';
-import { MemoryCardGameComponent } from './views/games/memory-card-game/memory-card-game.component';
 import { CountdownComponent } from './views/countdown/countdown.component';
 import { LoadingResultsComponent } from './views/loading-results/loading-results.component';
-import { SpotTheDifferenceComponent } from './views/games/spot-the-difference/spot-the-difference.component';
 import { GameTransitionComponent } from './views/game-transition/game-transition.component';
-import { ReactionTimeComponent } from './views/games/reaction-time/reaction-time.component';
 import { FinalResultsComponent } from './views/final-results/final-results.component';
+import { BeachTennisBetComponent } from './views/games/beach-tennis-bet/beach-tennis-bet.component';
 
 @Component({
   selector: 'app-root',
@@ -19,12 +17,10 @@ import { FinalResultsComponent } from './views/final-results/final-results.compo
     CommonModule,
     GameStateInfoComponent,
     StartSessionComponent,
-    MemoryCardGameComponent,
     CountdownComponent,
     LoadingResultsComponent,
-    SpotTheDifferenceComponent,
     GameTransitionComponent,
-    ReactionTimeComponent,
+    BeachTennisBetComponent,
     FinalResultsComponent
   ],
   standalone: true

--- a/src/app/services/beach-tennis-bet.service.ts
+++ b/src/app/services/beach-tennis-bet.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, filter, firstValueFrom } from 'rxjs';
+import { GameResults, GameService } from './game-session.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BeachTennisBetService implements GameService {
+  readonly song = 'edm.mp3';
+
+  private _running = new BehaviorSubject(false);
+  running$ = this._running.asObservable();
+
+  private _score = new BehaviorSubject(0);
+  score$ = this._score.asObservable();
+
+  private _remainingTime = new BehaviorSubject(0);
+  remainingTime$ = this._remainingTime.asObservable();
+
+  private _finished = new BehaviorSubject<GameResults | false>(false);
+
+  private bet: 'Team A' | 'Team B' | null = null;
+  private winner: 'Team A' | 'Team B' | null = null;
+
+  constructor() { }
+
+  gameFinished(): Promise<GameResults> {
+    return firstValueFrom(this._finished.asObservable().pipe(filter(r => !!r)));
+  }
+
+  startGame() {
+    this._running.next(true);
+    this._score.next(0);
+    this._remainingTime.next(0);
+    this._finished.next(false);
+    this.bet = null;
+    this.winner = null;
+  }
+
+  placeBet(team: 'Team A' | 'Team B') {
+    if (!this._running.value) {
+      return;
+    }
+    this.bet = team;
+    this.winner = Math.random() < 0.5 ? 'Team A' : 'Team B';
+    if (this.bet === this.winner) {
+      this._score.next(100);
+    } else {
+      this._score.next(0);
+    }
+    this.finishGame();
+  }
+
+  private finishGame() {
+    this._running.next(false);
+    this._finished.next({
+      score: this._score.value,
+      timeUsed: 0,
+      timeLeft: 0
+    });
+  }
+
+  get currentWinner(): 'Team A' | 'Team B' | null {
+    return this.winner;
+  }
+}

--- a/src/app/services/game-session.service.ts
+++ b/src/app/services/game-session.service.ts
@@ -1,9 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { BehaviorSubject, map, Observable, switchMap } from 'rxjs';
-import { MemoryCardGameService } from './memory-card-game.service';
-import { ProcessedGameResults, ProcessGameResultsParams, ResultsService } from './results.service';
-import { SpotTheDifferenceService } from './spot-the-difference.service';
-import { ReactionTimeService } from './reaction-time.service';
+import { ProcessedGameResults } from './results.service';
+import { BeachTennisBetService } from './beach-tennis-bet.service';
 
 interface GameSessionStep {
   id: string;
@@ -42,38 +40,21 @@ export interface GameTransitionParams {
 })
 export class GameSessionService {
 
-  private memoryCardGameService = inject(MemoryCardGameService);
-  private spotTheDifferenceService = inject(SpotTheDifferenceService);
-  private reactionTimeService = inject(ReactionTimeService);
-  private resultsService = inject(ResultsService);
+  private beachTennisBetService = inject(BeachTennisBetService);
 
   bipAudio = new Audio();
   finalBipAudio = new Audio();
 
   userName: string = '';
 
-  games: Game[] = [ 
+  games: Game[] = [
     {
-      id: 'memory',
-      title: 'Memory Card Game',
+      id: 'beach-tennis-bet',
+      title: 'Beach Tennis Bet',
       isGameStep: true,
-      service: this.memoryCardGameService,
+      service: this.beachTennisBetService,
       audio: new Audio()
     },
-    {
-      id: 'reaction-time',
-      title: 'Reaction Time Game',
-      isGameStep: true,
-      service: this.reactionTimeService,
-      audio: new Audio()
-    },
-    {
-      id: 'spot-the-difference',
-      title: 'Spot The Difference',
-      isGameStep: true,
-      service: this.spotTheDifferenceService,
-      audio: new Audio()
-    }, 
   ]
 
   gameResults: {[key: string]: GameResults} = {}
@@ -81,7 +62,7 @@ export class GameSessionService {
   steps: GameSessionStep[] = [
     {
       id: 'start',
-      title: 'Professions Game',
+      title: 'Beach Tennis Bet Game',
       isGameStep: false
     },
     {
@@ -134,12 +115,7 @@ export class GameSessionService {
   private _transitionParams = new BehaviorSubject<GameTransitionParams | null>(null);
   transitionParams$ = this._transitionParams.asObservable();
 
-  private _processedResults = new BehaviorSubject<ProcessedGameResults | null>(
-    {
-      "message": "Dados processados com sucesso",
-      "gptSummary": "Based on Alisson's performance with classical music in the memory game, it points towards a focus on detail and organization, indicating a fit for **Academics and Researchers**. This role supports analytical tasks and promotes concentration with music that enhances memory and focus.\n\n**Examples of Professions:**\n1. Research Scientist\n2. University Professor\n3. Historian"
-    }
-  );
+  private _processedResults = new BehaviorSubject<ProcessedGameResults | null>(null);
   processedResults$ = this._processedResults.asObservable();
 
   currentGame: Game | null = null;
@@ -160,8 +136,6 @@ export class GameSessionService {
 
   preloadImages() {
     const imageUrls = [
-      ...this.spotTheDifferenceService.imageSets.map(imageSet => imageSet.correctImage),
-      ...this.spotTheDifferenceService.imageSets.map(imageSet => imageSet.wrongImage),
       'assets/images/score.png',
       'assets/images/timer.png',
     ];
@@ -319,33 +293,13 @@ export class GameSessionService {
   }
 
   loadResults() {
-    const params: ProcessGameResultsParams = {
-      user: this.userName || '',
-      memoryGameResult: {
-        musicGenre: 'Classical',
-        percentageOfHits: this.gameResults['memory'].score,
-        timeToComplete: this.gameResults['memory'].timeLeft,
-        timeUsed: this.gameResults['memory'].timeUsed,
-      },
-      reactionGameResult: {
-        musicGenre: 'Electronic Dance Music',
-        percentageOfHits: this.gameResults['reaction-time'].score,
-        timeToComplete: this.gameResults['reaction-time'].timeLeft,
-        timeUsed: this.gameResults['reaction-time'].timeUsed,
-      },
-      spotTheDifferenceGameResult: {
-        musicGenre: 'Jazz',
-        percentageOfHits: this.gameResults['spot-the-difference'].score,
-        timeToComplete: this.gameResults['spot-the-difference'].timeLeft,
-        timeUsed: this.gameResults['spot-the-difference'].timeUsed,
-      }
-    }
-
-    this.resultsService.processGameResults(params).subscribe({
-      next: (results) => {
-        this._processedResults.next(results);
-        this.nextStep();
-      }
+    const resultText = this.gameResults['beach-tennis-bet']?.score === 100
+      ? 'You won the bet!'
+      : 'You lost the bet.';
+    this._processedResults.next({
+      message: resultText,
+      gptSummary: ''
     });
+    this.nextStep();
   }
 }

--- a/src/app/views/final-results/final-results.component.ts
+++ b/src/app/views/final-results/final-results.component.ts
@@ -17,7 +17,7 @@ export class FinalResultsComponent {
   public gameSessionService = inject(GameSessionService);
 
   formattedSummary$ = this.gameSessionService.processedResults$.pipe(
-    map(results => this.formatSummary(results?.gptSummary || ''))
+    map(results => this.formatSummary(results?.message || ''))
   );
 
   formatSummary(summary: string): string {

--- a/src/app/views/games/beach-tennis-bet/beach-tennis-bet.component.html
+++ b/src/app/views/games/beach-tennis-bet/beach-tennis-bet.component.html
@@ -1,0 +1,8 @@
+<div class="bet-container" *ngIf="betService.running$ | async">
+  <p>Who will win the match?</p>
+  <button (click)="choose('Team A')">Team A</button>
+  <button (click)="choose('Team B')">Team B</button>
+</div>
+<div class="result-container" *ngIf="!(betService.running$ | async)">
+  <p *ngIf="betService.currentWinner">Winner: {{ betService.currentWinner }}</p>
+</div>

--- a/src/app/views/games/beach-tennis-bet/beach-tennis-bet.component.scss
+++ b/src/app/views/games/beach-tennis-bet/beach-tennis-bet.component.scss
@@ -1,0 +1,6 @@
+.bet-container, .result-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}

--- a/src/app/views/games/beach-tennis-bet/beach-tennis-bet.component.ts
+++ b/src/app/views/games/beach-tennis-bet/beach-tennis-bet.component.ts
@@ -1,0 +1,18 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { BeachTennisBetService } from '../../../services/beach-tennis-bet.service';
+
+@Component({
+  selector: 'app-beach-tennis-bet',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './beach-tennis-bet.component.html',
+  styleUrl: './beach-tennis-bet.component.scss'
+})
+export class BeachTennisBetComponent {
+  betService = inject(BeachTennisBetService);
+
+  choose(team: 'Team A' | 'Team B') {
+    this.betService.placeBet(team);
+  }
+}

--- a/src/app/views/start-session/start-session.component.html
+++ b/src/app/views/start-session/start-session.component.html
@@ -1,9 +1,7 @@
 <div class="component-container">
   <p>
-    Welcome to our Professions Game! Here, you’ll play three fun games, starting with a memory game. 
-    <br> Each game comes with its own music to keep things lively.
-    <br> Based on your scores, we’ll suggest a profession that matches your skills.
-    <br> Don't forget to turn your volume on to enjoy the music!
+    Welcome to the Beach Tennis Bet Game! Pick who you think will win the match.
+    <br> Turn your volume on to enjoy the music!
     <br><br> Ready to start? Let’s go!
   </p>
 


### PR DESCRIPTION
## Summary
- add new `BeachTennisBetService` and component
- wire new game as the only gameplay step
- simplify final results display
- update start session intro

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684753e7dcc883318cea8f71222ca131